### PR TITLE
Added support for Webdriver Standalone

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ When using WebdriverIO Standalone, the `before` and `beforeTest` / `beforeScenar
 
 ```javascript
 import { remote } from 'webdriverio';
-import { WebdriverAjax } from 'wdio-intercept-service-main'
+import WebdriverAjax from 'wdio-intercept-service'
 
 const WDIO_OPTIONS = {
   port: 9515,

--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@ npm install wdio-intercept-service -D
 
 ## Usage
 
+### Usage with WebDriver CLI
+
 It should be as easy as adding wdio-intercept-service to your `wdio.conf.js`:
 
 ```javascript
@@ -36,6 +38,43 @@ exports.config = {
 ```
 
 and you're all set.
+
+### Usage with WebDriver Standalone
+
+When using WebdriverIO Standalone, the `before` and `beforeTest` / `beforeScenario` functions need to be called manually.
+
+```javascript
+import { remote } from 'webdriverio';
+import { WebdriverAjax } from 'wdio-intercept-service-main'
+
+const WDIO_OPTIONS = {
+  port: 9515,
+  path: '/',
+  capabilities: {
+    browserName: 'chrome'
+  },
+}
+
+let browser;
+const interceptServiceLauncher = WebdriverAjax();
+
+beforeAll(async () => {
+  browser = await remote(WDIO_OPTIONS)
+  interceptServiceLauncher.before(null, null, browser)
+})
+
+beforeEach(async () => {
+  interceptServiceLauncher.beforeTest()
+})
+
+afterAll(async () => {
+  await client.deleteSession()
+});
+
+describe('', async () => {
+  ... // See example usage
+});
+```
 
 Once initialized, some related functions are added to your browser command chain (see [API](#api)).
 

--- a/index.js
+++ b/index.js
@@ -15,7 +15,7 @@ class WebdriverAjax {
     this._wdajaxExpectations = [];
   }
 
-  before(config, capabilities, browser) {
+  before(_, __, browser) {
     /**
      * instance need to have addCommand method
      */
@@ -306,4 +306,3 @@ class WebdriverAjax {
 }
 
 exports.default = WebdriverAjax;
-exports.WebdriverAjax = WebdriverAjax;

--- a/index.js
+++ b/index.js
@@ -15,7 +15,7 @@ class WebdriverAjax {
     this._wdajaxExpectations = [];
   }
 
-  before() {
+  before(config, capabilities, browser) {
     /**
      * instance need to have addCommand method
      */
@@ -306,3 +306,4 @@ class WebdriverAjax {
 }
 
 exports.default = WebdriverAjax;
+exports.WebdriverAjax = WebdriverAjax;

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "@wdio/spec-reporter": "^7.6.0",
     "@wdio/static-server-service": "^7.6.0",
     "@wdio/sync": "^7.6.0",
-    "chromedriver": "^90.0.0",
+    "chromedriver": "^92.0.0",
     "husky": "4.2.5",
     "prettier": "2.3.0",
     "release-it": "^14.6.2",

--- a/test/spec/plugin_test.js
+++ b/test/spec/plugin_test.js
@@ -1,6 +1,8 @@
 'use strict';
 
 const assert = require('assert');
+const { remote } = require('webdriverio');
+const { WebdriverAjax } = require('../../index');
 
 describe('webdriverajax', function testSuite() {
   this.timeout(process.env.CI ? 100000 : 10000);
@@ -15,6 +17,24 @@ describe('webdriverajax', function testSuite() {
       return window.__webdriverajax;
     });
     assert.deepEqual(ret, { requests: [] });
+  });
+
+  it('sets up the interceptor in standalone mode', async () => {
+    const browser = await remote({
+      port: 9515,
+      path: '/',
+      capabilities: {
+        browserName: 'chrome',
+        'goog:chromeOptions': {
+          args: ['--headless'],
+        },
+      },
+    });
+
+    const webdriverAjax = new WebdriverAjax();
+    webdriverAjax.before(null, null, browser);
+
+    assert.equal(typeof browser.setupInterceptor, 'function');
   });
 
   it('should reset expectations', () => {

--- a/test/spec/plugin_test.js
+++ b/test/spec/plugin_test.js
@@ -2,7 +2,7 @@
 
 const assert = require('assert');
 const { remote } = require('webdriverio');
-const { WebdriverAjax } = require('../../index');
+const WebdriverAjax = require('../../index').default;
 
 describe('webdriverajax', function testSuite() {
   this.timeout(process.env.CI ? 100000 : 10000);


### PR DESCRIPTION
The before function is currently already being called with the arguments of config, capabilities, browser.
Since the browser object will be the same, this change allows the service to be compatible with the CLI Testrunner
and WebDriver standalone. Documentation in the README and a new test has been added also.

Closes #138 