### PR TITLE
feat(tests): Run tests for both Chrome and Firefox

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1094,6 +1094,12 @@
       "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
       "dev": true
     },
+    "adm-zip": {
+      "version": "0.5.5",
+      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.5.5.tgz",
+      "integrity": "sha512-IWwXKnCbirdbyXSfUDvCCrmYrOHANRZcc8NcRrvTlIApdl7PwE9oGcsYvNeJPAVY1M+70b4PxXGKIf8AEuiQ6w==",
+      "dev": true
+    },
     "agent-base": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
@@ -1380,6 +1386,12 @@
         "inherits": "^2.0.4",
         "readable-stream": "^3.4.0"
       }
+    },
+    "bluebird": {
+      "version": "3.7.2",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
+      "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==",
+      "dev": true
     },
     "body-parser": {
       "version": "1.19.0",
@@ -2848,6 +2860,15 @@
         "universalify": "^2.0.0"
       }
     },
+    "fs-minipass": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-2.1.0.tgz",
+      "integrity": "sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==",
+      "dev": true,
+      "requires": {
+        "minipass": "^3.0.0"
+      }
+    },
     "fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -2880,6 +2901,19 @@
       "dev": true,
       "requires": {
         "globule": "^1.0.0"
+      }
+    },
+    "geckodriver": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/geckodriver/-/geckodriver-2.0.4.tgz",
+      "integrity": "sha512-3Fu75v6Ov8h5Vt25+djJU56MJA2gRctgjhvG5xGzLFTQjltPz7nojQdBHbmgWznUt3CHl8VaiDn8MaepY7B0dA==",
+      "dev": true,
+      "requires": {
+        "adm-zip": "0.5.5",
+        "bluebird": "3.7.2",
+        "got": "11.8.2",
+        "https-proxy-agent": "5.0.0",
+        "tar": "6.1.9"
       }
     },
     "get-caller-file": {
@@ -4004,6 +4038,41 @@
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
       "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
       "dev": true
+    },
+    "minipass": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.1.5.tgz",
+      "integrity": "sha512-+8NzxD82XQoNKNrl1d/FSi+X8wAEWR+sbYAfIvub4Nz0d22plFG72CEVVaufV8PNf4qSslFTD8VMOxNVhHCjTw==",
+      "dev": true,
+      "requires": {
+        "yallist": "^4.0.0"
+      },
+      "dependencies": {
+        "yallist": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+          "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+          "dev": true
+        }
+      }
+    },
+    "minizlib": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-2.1.2.tgz",
+      "integrity": "sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==",
+      "dev": true,
+      "requires": {
+        "minipass": "^3.0.0",
+        "yallist": "^4.0.0"
+      },
+      "dependencies": {
+        "yallist": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+          "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+          "dev": true
+        }
+      }
     },
     "mkdirp": {
       "version": "1.0.4",
@@ -5664,6 +5733,34 @@
         "has-flag": "^4.0.0"
       }
     },
+    "tar": {
+      "version": "6.1.9",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-6.1.9.tgz",
+      "integrity": "sha512-XjLaMNl76o07zqZC/aW4lwegdY07baOH1T8w3AEfrHAdyg/oYO4ctjzEBq9Gy9fEP9oHqLIgvx6zuGDGe+bc8Q==",
+      "dev": true,
+      "requires": {
+        "chownr": "^2.0.0",
+        "fs-minipass": "^2.0.0",
+        "minipass": "^3.0.0",
+        "minizlib": "^2.1.1",
+        "mkdirp": "^1.0.3",
+        "yallist": "^4.0.0"
+      },
+      "dependencies": {
+        "chownr": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/chownr/-/chownr-2.0.0.tgz",
+          "integrity": "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==",
+          "dev": true
+        },
+        "yallist": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+          "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+          "dev": true
+        }
+      }
+    },
     "tar-fs": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.0.0.tgz",
@@ -5997,6 +6094,33 @@
         "@wdio/logger": "^7.5.3",
         "fs-extra": "^9.1.0",
         "split2": "^3.2.2"
+      },
+      "dependencies": {
+        "fs-extra": {
+          "version": "9.1.0",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
+          "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
+          "dev": true,
+          "requires": {
+            "at-least-node": "^1.0.0",
+            "graceful-fs": "^4.2.0",
+            "jsonfile": "^6.0.1",
+            "universalify": "^2.0.0"
+          }
+        }
+      }
+    },
+    "wdio-geckodriver-service": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/wdio-geckodriver-service/-/wdio-geckodriver-service-2.0.3.tgz",
+      "integrity": "sha512-8I5yh9DHReF8XW2DEHwcAgiHX9r6VfYQyXyn2GoS+SOaRNKQr0lMW3Oslvwm9Mc4O8asvVyqJL5fM5u8C8/lEA==",
+      "dev": true,
+      "requires": {
+        "@wdio/logger": "^7.5.3",
+        "fs-extra": "^9.0.1",
+        "get-port": "^5.1.1",
+        "split2": "^3.2.2",
+        "tcp-port-used": "^1.0.1"
       },
       "dependencies": {
         "fs-extra": {

--- a/package.json
+++ b/package.json
@@ -50,10 +50,12 @@
     "eslint-config-prettier": "^8.3.0",
     "eslint-plugin-prettier": "^4.0.0",
     "eslint-plugin-wdio": "^7.4.2",
+    "geckodriver": "^2.0.4",
     "husky": "^7.0.4",
     "prettier": "^2.4.1",
     "release-it": "^14.11.6",
     "wdio-chromedriver-service": "^7.2.2",
+    "wdio-geckodriver-service": "^2.0.3",
     "webdriverio": "^7.16.3"
   }
 }

--- a/test/spec/plugin_test.js
+++ b/test/spec/plugin_test.js
@@ -318,12 +318,12 @@ describe('webdriverajax', function testSuite() {
       );
     });
 
-    it('converts Blob response types', () => {
-      browser.url('/get.html');
-      browser.setupInterceptor();
-      $('#blobbutton').click();
-      browser.pause(wait);
-      const request = browser.getRequest(0);
+    it('converts Blob response types', async function () {
+      await browser.url('/get.html');
+      await browser.setupInterceptor();
+      await $('#blobbutton').click();
+      await browser.pause(wait);
+      const request = await browser.getRequest(0);
       assert.equal(request.method, 'GET');
       assert.equal(request.url, '/get.json');
       assert.equal(request.response.statusCode, 200);

--- a/test/wdio.conf.js
+++ b/test/wdio.conf.js
@@ -16,19 +16,7 @@ const chromedriver = !process.env.CHROMEWEBDRIVER
       },
     ];
 
-const geckodriver = !process.env.GECKOWEBDRIVER
-  ? 'geckodriver' // running locally
-  : [
-      'geckodriver',
-      {
-        args: [
-          `--binary=${path.join(
-            process.env.GECKOWEBDRIVER,
-            process.platform === 'win32' ? 'geckodriver.exe' : 'geckodriver'
-          )}`,
-        ],
-      },
-    ];
+const geckodriver = 'geckodriver'; // running locally, or in CI.
 
 exports.config = {
   //

--- a/test/wdio.conf.js
+++ b/test/wdio.conf.js
@@ -16,6 +16,20 @@ const chromedriver = !process.env.CHROMEWEBDRIVER
       },
     ];
 
+const geckodriver = !process.env.GECKOWEBDRIVER
+  ? 'geckodriver' // running locally
+  : [
+      'geckodriver',
+      {
+        args: [
+          `--binary=${path.join(
+            process.env.GECKOWEBDRIVER,
+            process.platform === 'win32' ? 'geckodriver.exe' : 'geckodriver'
+          )}`,
+        ],
+      },
+    ];
+
 exports.config = {
   //
   // ====================
@@ -67,6 +81,12 @@ exports.config = {
       browserName: 'chrome',
       'goog:chromeOptions': {
         args: ['--headless', '--disable-gpu'],
+      },
+    },
+    {
+      browserName: 'firefox',
+      'moz:firefoxOptions': {
+        args: ['-headless'],
       },
     },
   ],
@@ -131,6 +151,7 @@ exports.config = {
   // Services to use
   services: [
     chromedriver,
+    geckodriver,
     [
       'static-server',
       {


### PR DESCRIPTION
`npm test` will now test both chrome and firefox browsers.

Refs #152 


Adding support for testing against Safari will require a different approach. My first thought is passing an environment variable and conditionally generating a `wdio.conf.js` that excludes the chrome & firefox capabilities. The GitHub Action job for testing would then be updated with a macOS host test that specifies this environment variable. (I don't plan to implement this myself, btw.)