### PR TITLE
refactor(tests): Replace explicit pauses with DOM polling

### DIFF
--- a/test/site/get.html
+++ b/test/site/get.html
@@ -10,6 +10,7 @@
   <button id="button">Press me</button>
   <button id="fetchbutton">No, press me!</button>
   <button id="blobbutton">You should really press me!</button>
+  <div id="response"></div>
   <script>
     'use strict';
 
@@ -19,6 +20,7 @@
       button.addEventListener('click', function (evt) {
         var xhr = new XMLHttpRequest();
         xhr.open('GET', '/get.json');
+        xhr.addEventListener('load', () => document.querySelector('#response').textContent += "XHR response type: " + xhr.responseType);
         xhr.send();
       });
 
@@ -27,12 +29,13 @@
         var xhr = new XMLHttpRequest();
         xhr.responseType = 'blob';
         xhr.open('GET', '/get.json');
+        xhr.addEventListener('load', () => document.querySelector('#response').textContent += "XHR Blob response\n" + xhr.responseType);
         xhr.send();
       });
 
       var fetchButton = document.querySelector('#fetchbutton');
       fetchButton.addEventListener('click', function (evt) {
-        fetch('/get.json');
+        fetch('/get.json').then(() => document.querySelector('#response').textContent += "Fetched\n");
       });
 
     })(window, window.document);

--- a/test/site/multiple_methods.html
+++ b/test/site/multiple_methods.html
@@ -9,6 +9,7 @@
 <p id="text">This file makes ajax requests to different endpoints</p>
 <button id="getbutton">Press me for GET!</button>
 <button id="postbutton">Press me for POST!</button>
+<div id="response"></div>
 <script>
     'use strict';
 
@@ -18,6 +19,7 @@
         button.addEventListener('click', function (evt) {
             var xhr = new XMLHttpRequest();
             xhr.open('GET', '/get.json');
+            xhr.addEventListener('load', () => document.querySelector('#response').textContent += "XHR response type: " + xhr.responseType);
             xhr.send();
         });
 
@@ -28,6 +30,7 @@
             form.append('foo', 'bar');
             xhr.open('POST', '/post.json');
             var payload = form;
+            xhr.addEventListener('load', () => document.querySelector('#response').textContent += "XHR response type: " + xhr.responseType);
             xhr.send(payload);
         });
 

--- a/test/site/page_change.html
+++ b/test/site/page_change.html
@@ -9,20 +9,22 @@
   <p id="text">
     This file makes an ajax GET request to /get.json and changes the url to get.html
   </p>
-  <button id="button1">Press me</button>
-  <button id="button2">Press me already!</button>
+  <button id="stay">Press me</button>
+  <button id="redirect">Press me already!</button>
+  <div id="response">See you later!</div>
   <script>
     'use strict';
 
     (function (window, document) {
 
-      var button1 = document.querySelector('#button1');
-      var button2 = document.querySelector('#button2');
+      var button1 = document.querySelector('#stay');
+      var button2 = document.querySelector('#redirect');
 
       button1.addEventListener('click', function (evt) {
 
         var xhr = new XMLHttpRequest();
         xhr.open('GET', '/get.json');
+        xhr.addEventListener('load', () => document.querySelector('#response').textContent += "XHR response type: " + xhr.responseType);
         xhr.send();
 
       });

--- a/test/site/post.html
+++ b/test/site/post.html
@@ -10,6 +10,7 @@
   <button id="buttonstring">Press me for string data</button>
   <button id="buttonjson">Press me for JSON data</button>
   <button id="buttonform">Press me for form data</button>
+  <div id="response"></div>
   <script>
     'use strict';
 
@@ -21,6 +22,7 @@
         var xhr = new XMLHttpRequest();
         xhr.open('POST', '/post.json');
         var payload = 'foobar';
+        xhr.addEventListener('load', () => document.querySelector('#response').textContent += "XHR response type: " + xhr.responseType);
         xhr.send(payload);
       });
 
@@ -31,6 +33,7 @@
         xhr.open('POST', '/post.json');
         xhr.setRequestHeader('Content-Type', 'application/json');
         var payload = JSON.stringify({ foo: 'bar' });
+        xhr.addEventListener('load', () => document.querySelector('#response').textContent += "XHR response type: " + xhr.responseType);
         xhr.send(payload);
       });
 
@@ -42,6 +45,7 @@
         form.append('foo', 'bar');
         xhr.open('POST', '/post.json');
         var payload = form;
+        xhr.addEventListener('load', () => document.querySelector('#response').textContent += "XHR response type: " + xhr.responseType);
         xhr.send(payload);
       });
 

--- a/test/site/postfetch.html
+++ b/test/site/postfetch.html
@@ -10,6 +10,7 @@
   <button id="buttonstring">Press me for string data</button>
   <button id="buttonjson">Press me for JSON data</button>
   <button id="buttonform">Press me for form data</button>
+  <div id="response"></div>
   <script>
     'use strict';
 
@@ -20,7 +21,7 @@
         fetch('/post.json', {
           method: 'POST',
           body: 'foobar',
-        });
+        }).then(() => document.querySelector('#response').textContent += "posted string\n");;
       });
 
       var buttonjson = document.querySelector('#buttonjson');
@@ -31,7 +32,7 @@
             'Content-Type': 'application/json'
           },
           body: JSON.stringify({ foo: 'bar' }),
-        });
+        }).then(() => document.querySelector('#response').textContent += "posted json\n");;
       });
 
     })(window, window.document);

--- a/test/spec/plugin_test.js
+++ b/test/spec/plugin_test.js
@@ -14,6 +14,18 @@ describe('webdriverajax', function testSuite() {
 
   const wait = process.env.CI ? 10000 : 1000;
 
+  const completedRequest = async function (sel) {
+    const elem = await browser.$('#response');
+    const initial = await elem.getText();
+    $(sel).click();
+    return elem.waitUntil(
+      async function () {
+        return (await this.getText()) !== initial;
+      },
+      { timeout: wait }
+    );
+  };
+
   it('sets up the interceptor', async function () {
     assert.equal(typeof browser.setupInterceptor, 'function');
     await browser.url('/get.html');
@@ -56,8 +68,7 @@ describe('webdriverajax', function testSuite() {
       await browser.url('/get.html');
       await browser.setupInterceptor();
       await browser.expectRequest('GET', '/get.json', 200);
-      await $('#button').click();
-      await browser.pause(wait);
+      await completedRequest('#button');
       await browser.assertRequests();
       await browser.assertExpectedRequestsOnly();
     });
@@ -66,8 +77,7 @@ describe('webdriverajax', function testSuite() {
       await browser.url('/get.html');
       await browser.setupInterceptor();
       await browser.expectRequest('GET', /get\.json/, 200);
-      await $('#button').click();
-      await browser.pause(wait);
+      await completedRequest('#button');
       await browser.assertRequests();
       await browser.assertExpectedRequestsOnly();
     });
@@ -77,8 +87,7 @@ describe('webdriverajax', function testSuite() {
       await browser.setupInterceptor();
       await browser.expectRequest('GET', '/get.json', 200);
       await browser.expectRequest('GET', '/get.json', 200);
-      await $('#button').click();
-      await browser.pause(wait);
+      await completedRequest('#button');
       assert.rejects(() => browser.assertRequests(), /Expected/);
     });
 
@@ -86,8 +95,7 @@ describe('webdriverajax', function testSuite() {
       await browser.url('/get.html');
       await browser.setupInterceptor();
       await browser.expectRequest('PUT', '/get.json', 200);
-      await $('#button').click();
-      await browser.pause(wait);
+      await completedRequest('#button');
       assert.rejects(() => browser.assertRequests(), /PUT/);
     });
 
@@ -95,8 +103,7 @@ describe('webdriverajax', function testSuite() {
       await browser.url('/get.html');
       await browser.setupInterceptor();
       await browser.expectRequest('GET', '/wrong.json', 200);
-      await $('#button').click();
-      await browser.pause(wait);
+      await completedRequest('#button');
       assert.rejects(() => browser.assertRequests(), /wrong\.json/);
     });
 
@@ -104,8 +111,7 @@ describe('webdriverajax', function testSuite() {
       await browser.url('/get.html');
       await browser.setupInterceptor();
       await browser.expectRequest('GET', /wrong\.json/, 200);
-      await $('#button').click();
-      await browser.pause(wait);
+      await completedRequest('#button');
       assert.rejects(() => browser.assertRequests(), /get\.json/);
     });
 
@@ -113,16 +119,14 @@ describe('webdriverajax', function testSuite() {
       await browser.url('/get.html');
       await browser.setupInterceptor();
       await browser.expectRequest('GET', '/get.json', 404);
-      await $('#button').click();
-      await browser.pause(wait);
+      await completedRequest('#button');
       assert.rejects(() => browser.assertRequests(), /404/);
     });
 
     it('can access a certain request', async function () {
       await browser.url('/get.html');
       await browser.setupInterceptor();
-      await $('#button').click();
-      await browser.pause(wait);
+      await completedRequest('#button');
       const request = await browser.getRequest(0);
       assert.equal(request.method, 'GET');
       assert.equal(request.url, '/get.json');
@@ -134,10 +138,8 @@ describe('webdriverajax', function testSuite() {
     it('can get multiple requests at once', async function () {
       await browser.url('/get.html');
       await browser.setupInterceptor();
-      await $('#button').click();
-      await browser.pause(wait);
-      await $('#button').click();
-      await browser.pause(wait);
+      await completedRequest('#button');
+      await completedRequest('#button');
       const requests = await browser.getRequests();
       assert(Array.isArray(requests));
       assert.equal(requests.length, 2);
@@ -148,10 +150,8 @@ describe('webdriverajax', function testSuite() {
     it('can get multiple request one by one', async function () {
       await browser.url('/get.html');
       await browser.setupInterceptor();
-      await $('#button').click();
-      await browser.pause(wait);
-      await $('#button').click();
-      await browser.pause(wait);
+      await completedRequest('#button');
+      await completedRequest('#button');
       const firstRequest = await browser.getRequest(0);
       assert.equal(firstRequest.method, 'GET');
       const secondRequest = await browser.getRequest(1);
@@ -321,8 +321,7 @@ describe('webdriverajax', function testSuite() {
     it('converts Blob response types', async function () {
       await browser.url('/get.html');
       await browser.setupInterceptor();
-      await $('#blobbutton').click();
-      await browser.pause(wait);
+      await completedRequest('#blobbutton');
       const request = await browser.getRequest(0);
       assert.equal(request.method, 'GET');
       assert.equal(request.url, '/get.json');
@@ -337,8 +336,7 @@ describe('webdriverajax', function testSuite() {
       await browser.url('/get.html');
       await browser.setupInterceptor();
       await browser.expectRequest('GET', '/get.json', 200);
-      await $('#fetchbutton').click();
-      await browser.pause(wait);
+      await completedRequest('#fetchbutton');
       await browser.assertRequests();
       await browser.assertExpectedRequestsOnly();
     });
@@ -346,8 +344,7 @@ describe('webdriverajax', function testSuite() {
     it('can access a certain request', async function () {
       await browser.url('/get.html');
       await browser.setupInterceptor();
-      await $('#fetchbutton').click();
-      await browser.pause(wait);
+      await completedRequest('#fetchbutton');
       const request = await browser.getRequest(0);
       assert.equal(request.method, 'GET');
       assert.equal(request.url, '/get.json');

--- a/test/spec/plugin_test.js
+++ b/test/spec/plugin_test.js
@@ -25,7 +25,7 @@ describe('webdriverajax', function testSuite() {
       async function () {
         return (await this.getText()) !== initial;
       },
-      { timeout: wait }
+      { timeout: wait, interval: 5 }
     );
   };
 


### PR DESCRIPTION
Massively speeds up test execution:
1. Clicking buttons in the mock site updates the DOM after the request completes
2. Add helper method to test spec file that reads DOM preclick and then polls for changes after clicking
3. Tests wait for helper to detect difference in DOM, rather than pausing for 10 seconds in CI

I also fixed a redirection test that wasn't actually any different than the standard "it can spy on GET requests" tests, because it clicked the wrong button.