### PR TITLE
fix(fetch-api,types): Check for `URL` fetch inputs, fix return type for `getExpectations`

### DIFF
--- a/lib/interceptor.js
+++ b/lib/interceptor.js
@@ -30,27 +30,32 @@ var interceptor = {
         var request = {
           method: 'GET',
           requestHeaders: {},
+          requestBody: undefined,
+          url: '',
           headers: {},
         };
         var input = arguments[0];
         var init = arguments[1];
         if (typeof input == 'string') {
           request.url = input;
+        } else if (input instanceof URL) {
+          request.url = input.href;
         } else {
           if (input instanceof Request) {
             // Request object
             var clonedRequest = input.clone();
             request.requestBody = clonedRequest.text();
+            request.url = clonedRequest.url;
+            request.requestHeaders = parseHeaders(clonedRequest.headers);
+            request.method = clonedRequest.method;
           } else {
+            console.error('Unhandled input type to fetch API!');
             request.requestBody = input.body;
           }
-          request.url = clonedRequest.url;
-          request.requestHeaders = parseHeaders(clonedRequest.headers);
-          request.method = clonedRequest.method;
         }
         if (init) {
-          request.requestBody = init.body ? init.body : request.requestBody;
-          request.method = init.method ? init.method : request.method;
+          if (typeof init.body !== 'undefined') request.requestBody = init.body;
+          if (typeof init.method !== 'undefined') request.method = init.method;
           request.requestHeaders = parseHeaders(init.headers);
         }
 

--- a/package.json
+++ b/package.json
@@ -57,5 +57,12 @@
     "wdio-chromedriver-service": "^7.2.2",
     "wdio-geckodriver-service": "^2.0.3",
     "webdriverio": "^7.16.3"
-  }
+  },
+  "files": [
+    "lib/",
+    "types/",
+    "index.js",
+    "LICENSE",
+    "*.md"
+  ]
 }

--- a/test/site/get.html
+++ b/test/site/get.html
@@ -10,6 +10,8 @@
   <button id="button">Press me</button>
   <button id="fetchbutton">No, press me!</button>
   <button id="blobbutton">You should really press me!</button>
+  <button id="urlbutton">URL input!</button>
+  <button id="urlfetchbutton">URL input!</button>
   <div id="response"></div>
   <script>
     'use strict';
@@ -33,9 +35,21 @@
         xhr.send();
       });
 
+      document.querySelector('#urlbutton').addEventListener('click', function (evt) {
+        var xhr = new XMLHttpRequest();
+        xhr.open('GET', new URL('/get.json', window.location.origin));
+        xhr.addEventListener('load', () => document.querySelector('#response').textContent += "XHR opened with URL\n");
+        xhr.send();
+      });
+
       var fetchButton = document.querySelector('#fetchbutton');
       fetchButton.addEventListener('click', function (evt) {
         fetch('/get.json').then(() => document.querySelector('#response').textContent += "Fetched\n");
+      });
+
+      document.querySelector('#urlfetchbutton').addEventListener('click', function (evt) {
+        fetch(new URL('/get.json', window.location.origin))
+          .then(() => document.querySelector('#response').textContent += 'Fetched URL input\n');
       });
 
     })(window, window.document);

--- a/test/spec/plugin_test.js
+++ b/test/spec/plugin_test.js
@@ -76,6 +76,15 @@ describe('webdriverajax', function testSuite() {
       await browser.assertExpectedRequestsOnly();
     });
 
+    it('can intercept requests opened with URL objects', async function () {
+      await browser.url('/get.html');
+      await browser.setupInterceptor();
+      await browser.expectRequest('GET', /\/get\.json/, 200);
+      await completedRequest('#urlbutton');
+      await browser.assertRequests();
+      await browser.assertExpectedRequestsOnly();
+    });
+
     it('can use regular expressions for urls', async function () {
       await browser.url('/get.html');
       await browser.setupInterceptor();
@@ -320,6 +329,15 @@ describe('webdriverajax', function testSuite() {
       await browser.setupInterceptor();
       await browser.expectRequest('GET', '/get.json', 200);
       await completedRequest('#fetchbutton');
+      await browser.assertRequests();
+      await browser.assertExpectedRequestsOnly();
+    });
+
+    it('can intercept when input is URL object', async function () {
+      await browser.url('/get.html');
+      await browser.setupInterceptor();
+      await browser.expectRequest('GET', /\/get\.json/, 200);
+      await completedRequest('#urlfetchbutton');
       await browser.assertRequests();
       await browser.assertExpectedRequestsOnly();
     });

--- a/test/wdio.conf.js
+++ b/test/wdio.conf.js
@@ -115,28 +115,6 @@ exports.config = {
   // Services take over a specific job you don't want to take care of. They enhance
   // your test setup with almost no effort. Unlike plugins, they don't add new
   // commands. Instead, they hook themselves up into the test process.
-  // services: [],//
-  // Framework you want to run your specs with.
-  // The following are supported: Mocha, Jasmine, and Cucumber
-  // see also: https://webdriver.io/docs/frameworks.html
-  //
-  // Make sure you have the wdio adapter package for the specific framework installed
-  // before running any tests.
-  framework: 'mocha',
-  //
-  // Test reporter for stdout.
-  // The only one supported by default is 'dot'
-  // see also: https://webdriver.io/docs/dot-reporter.html
-  reporters: ['spec'],
-
-  //
-  // Options to be passed to Mocha.
-  // See the full list at http://mochajs.org/
-  mochaOpts: {
-    ui: 'bdd',
-    timeout: 60000,
-  },
-  // Services to use
   services: [
     chromedriver,
     geckodriver,
@@ -157,123 +135,23 @@ exports.config = {
     ],
     [plugin, {}],
   ],
+  // Framework you want to run your specs with.
+  // The following are supported: Mocha, Jasmine, and Cucumber
+  // see also: https://webdriver.io/docs/frameworks.html
   //
-  // =====
-  // Hooks
-  // =====
-  // WebdriverIO provides several hooks you can use to interfere with the test process in order to enhance
-  // it and to build services around it. You can either apply a single function or an array of
-  // methods to it. If one of them returns with a promise, WebdriverIO will wait until that promise got
-  // resolved to continue.
-  /**
-   * Gets executed once before all workers get launched.
-   * @param {Object} config wdio configuration object
-   * @param {Array.<Object>} capabilities list of capabilities details
-   */
-  // onPrepare() {
-  // },
-  /**
-   * Gets executed just before initialising the webdriver session and test framework. It allows you
-   * to manipulate configurations depending on the capability or spec.
-   * @param {Object} config wdio configuration object
-   * @param {Array.<Object>} capabilities list of capabilities details
-   * @param {Array.<String>} specs List of spec file paths that are to be run
-   */
-  // beforeSession: function (config, capabilities, specs) {
-  // },
-  /**
-   * Gets executed before test execution begins. At this point you can access to all global
-   * variables like `browser`. It is the perfect place to define custom commands.
-   * @param {Array.<Object>} capabilities list of capabilities details
-   * @param {Array.<String>} specs List of spec file paths that are to be run
-   */
-  // before: function (capabilities, specs) {
-  // },
-  /**
-   * Runs before a WebdriverIO command gets executed.
-   * @param {String} commandName hook command name
-   * @param {Array} args arguments that command would receive
-   */
-  // beforeCommand: function (commandName, args) {
-  // },
+  // Make sure you have the wdio adapter package for the specific framework installed
+  // before running any tests.
+  framework: 'mocha',
+  //
+  // Test reporter for stdout.
+  // The only one supported by default is 'dot'
+  // see also: https://webdriver.io/docs/dot-reporter.html
+  reporters: ['spec'],
 
-  /**
-   * Hook that gets executed before the suite starts
-   * @param {Object} suite suite details
-   */
-  // beforeSuite: function (suite) {
-  // },
-  /**
-   * Function to be executed before a test (in Mocha/Jasmine) or a step (in Cucumber) starts.
-   * @param {Object} test test details
-   */
-  // beforeTest: function (test) {
-  // },
-  /**
-   * Hook that gets executed _before_ a hook within the suite starts (e.g. runs before calling
-   * beforeEach in Mocha)
-   */
-  // beforeHook: function () {
-  // },
-  /**
-   * Hook that gets executed _after_ a hook within the suite starts (e.g. runs after calling
-   * afterEach in Mocha)
-   */
-  // afterHook: function () {
-  // },
-  /**
-   * Function to be executed after a test (in Mocha/Jasmine) or a step (in Cucumber) starts.
-   * @param {Object} test test details
-   */
-  // afterTest: function (test) {
-  // },
-  /**
-   * Hook that gets executed after the suite has ended
-   * @param {Object} suite suite details
-   */
-  // afterSuite: function (suite) {
-  // },
-
-  /**
-   * Runs after a WebdriverIO command gets executed
-   * @param {String} commandName hook command name
-   * @param {Array} args arguments that command would receive
-   * @param {Number} result 0 - command success, 1 - command error
-   * @param {Object} error error object if any
-   */
-  // afterCommand: function (commandName, args, result, error) {
-  // },
-  /**
-   * Gets executed after all tests are done. You still have access to all global variables from
-   * the test.
-   * @param {Number} result 0 - test pass, 1 - test fail
-   * @param {Array.<Object>} capabilities list of capabilities details
-   * @param {Array.<String>} specs List of spec file paths that ran
-   */
-  // after: function (result, capabilities, specs) {
-  // },
-  /**
-   * Gets executed right after terminating the webdriver session.
-   * @param {Object} config wdio configuration object
-   * @param {Array.<Object>} capabilities list of capabilities details
-   * @param {Array.<String>} specs List of spec file paths that ran
-   */
-  // afterSession: function (config, capabilities, specs) {
-  // },
-  /**
-   * Gets executed after all workers got shut down and the process is about to exit.
-   * @param {Object} exitCode 0 - success, 1 - fail
-   * @param {Object} config wdio configuration object
-   * @param {Array.<Object>} capabilities list of capabilities details
-   * @param {<Object>} results object containing test results
-   */
-  // onComplete() {
-  // }
-  /**
-   * Gets executed when a refresh happens.
-   * @param {String} oldSessionId session ID of the old session
-   * @param {String} newSessionId session ID of the new session
-   */
-  //onReload: function(oldSessionId, newSessionId) {
-  //}
+  // Options to be passed to Mocha.
+  // See the full list at http://mochajs.org/
+  mochaOpts: {
+    ui: 'bdd',
+    timeout: 60000,
+  },
 };

--- a/types/wdio-intercept-service.d.ts
+++ b/types/wdio-intercept-service.d.ts
@@ -47,7 +47,7 @@ declare module WebdriverIO {
     assertExpectedRequestsOnly: (inOrder?: boolean) => AsyncSync<BrowserObject>;
     resetExpectations: () => AsyncSync<BrowserObject>;
     getExpectations: () => AsyncSync<
-      WdioInterceptorService.InterceptedRequest[]
+      WdioInterceptorService.ExpectedRequest[]
     >;
     getRequest: (
       index: number


### PR DESCRIPTION
 - fix return type of the `getExpectations` method
 - fix uncaught TypeError when the browser's fetch is invoked with a URL object, rather than a string or a Request.
   The error would be thrown when attempting to access `clonedRequest.url`, since `clonedRequest` was not initialized in the non-`Request` branch for the input argument.
 - Add support for URL inputs to fetch

There are two adhoc changes as well:
 - Remove cruft from the wdio.conf.js spec file that we don't need to customize for this library's tests. If we did need to customize them, we would want to pull from the latest available template anyway.
 - Avoid publishing nonessential files (like eslint configs)