### PR TITLE
feat: Track and allow querying in-flight requests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 errorShots
 node_modules
-test/logs
+test/**/logs
+test/**/dist

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,26 @@
 ## wdio-intercept-service changelog
 
+### [ [>](https://github.com/webdriverio-community/wdio-intercept-service/tree/v.next) ] v.next / <DATE>
+- Intercept HTTP requests upon initiation, rather than completion (thanks @tehhowch)
+
+### [ [>](https://github.com/webdriverio-community/wdio-intercept-service/tree/v4.1.10) ] 4.1.10 / 16.11.2021
+* Support fetch requests opened with `URL` objects (thanks @tehhowch)
+* Fix return type for `browser.getExpectations()` (thanks @tehhowch)
+
+### [ [>](https://github.com/webdriverio-community/wdio-intercept-service/tree/v4.1.9) ] 4.1.9 / 03.11.2021
+* Run e2e tests in async mode (thanks @tehhowch)
+* Support 'blob' response types in XHR requests (thanks @tehhowch)
+* Run e2e tests for Firefox, too (thanks @tehhowch)
+
+### [ [>](https://github.com/webdriverio-community/wdio-intercept-service/tree/v4.1.8) ] 4.1.8 / 28.10.2021
+* Maintenance upgrade to help enforce IE compatability (thanks @tehhowch)
+
+### [ [>](https://github.com/webdriverio-community/wdio-intercept-service/tree/v4.1.7) ] 4.1.7 / 04.08.2021
+* Add support for WebdriverIO standalone mode (thanks @juenobueno)
+
+### [ [>](https://github.com/webdriverio-community/wdio-intercept-service/tree/v4.1.6) ] 4.1.6 / 19.05.2021
+* Maintenance upgrades (thanks @christian-bromann)
+
 ### [ [>](https://github.com/chmanie/wdio-intercept-service/tree/v4.1.4) ] 4.1.4 / 19.04.2021
 Improved support for parallelization (thanks @RaulGDMM)
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ There's one catch though: you can't intercept HTTP calls that are initiated on p
 
 ## Prerequisites
 
-* webdriver.io **v5.x**.
+* webdriver.io **v5.x** or newer.
 
 **Heads up! If you're still using webdriver.io v4, please use the v2.x branch of this plugin!**
 
@@ -132,23 +132,26 @@ Helper method. Returns all the expectations you've made up until that point
 
 Helper method. Resets all the expectations you've made up until that point
 
-### browser.assertRequests()
+### browser.assertRequests({ orderBy?: 'START' | 'END' })
 
 Call this method when all expected ajax requests are finished. It compares the expectations to the actual requests made and asserts the following:
 
 - Count of the requests that were made
-- The order of the requests
+- The order of the requests (defaults to `orderBy: 'END'`, i.e. when the requests were completed)
 - The method, the URL and the statusCode should match for every request made
 
-### browser.assertExpectedRequestsOnly(inOrder?: boolean)
+### browser.assertExpectedRequestsOnly({ inOrder?: boolean, orderBy?: 'START' | 'END' })
 
-Similar to `browser.assertRequests`, but validates only the requests you specify in your `expectRequest` directives, without having to map out all the network requests that might happen around that. If `inOrder` equals to `true` (default), the requests are expected to be made in the same order as they were setup with `expectRequest`.
+Similar to `browser.assertRequests`, but validates only the requests you specify in your `expectRequest` directives, without having to map out all the network requests that might happen around that. If `inOrder` option is `true` (default), the requests are expected to be found in the same order as they were setup with `expectRequest`.
 
-### browser.getRequest(index: number)
+### browser.getRequest(index: number, { includePending?: boolean, orderBy?: 'START' | 'END' })
 
-To make more sophisticated assertions about a specific request you can get details for a specific request after it is finished. You have to provide the index of the request you want to access in the order the requests were initiated (starting with 0).
+To make more sophisticated assertions about a specific request you can get details for a specific request. You have to provide the 0-based index of the request you want to access, in the order the requests were completed (default), or initiated (by passing the `orderBy: 'START'` option).
 
 * `index` (`Number`): number of the request you want to access
+* `options` (`object`): Request options
+* `options.includePending` (`boolean`): Whether not-yet-completed requests should be returned. By default, this is false, to match the behavior of the library in v4.1.10 and earlier.
+* `options.orderBy` (`'START' | 'END'`): How the requests should be ordered. By default, this is `'END'`, to match the behavior of the library in v4.1.10 and earlier. If `'START'`, the requests will be ordered by the time of initiation, rather than the time of request completion. (Since a pending request has not yet completed, when ordering by `'END'` all pending requests will come after all completed requests.)
 
 **Returns** `request` object:
 
@@ -156,9 +159,10 @@ To make more sophisticated assertions about a specific request you can get detai
 * `request.method`: used HTTP method
 * `request.body`: payload/body data used in request
 * `request.headers`: request http headers as JS object
-* `request.response.headers`: response http headers as JS object
-* `request.response.body`: response body (will be parsed as JSON if possible)
-* `request.response.statusCode`: response status code
+* `request.pending`: boolean flag for whether this request is complete (i.e. has a `response` property), or in-flight.
+* `request.response?.headers`: response http headers as JS object
+* `request.response?.body`: response body (will be parsed as JSON if possible)
+* `request.response?.statusCode`: response status code
 
 **A note on `request.body`:** wdio-intercept-service will try to parse the request body as follows:
 
@@ -170,12 +174,18 @@ To make more sophisticated assertions about a specific request you can get detai
 
 **For the `fetch` API, we only support string and JSON data!**
 
-### browser.getRequests()
+### browser.getRequests(options)
 
-Get all captured requests as an array.
+Get all captured requests as an array, supporting the same options as `getRequest`.
 
 **Returns** array of `request` objects.
 
+
+### browser.hasPendingRequests()
+
+A utility method that checks whether any HTTP requests are still pending. Can be used by tests to ensure all requests have completed within a reasonable amount of time, or to verify that a call to `getRequests()` or `assertRequests()` will include all of the desired HTTP requests.
+
+**Returns** boolean
 ## TypeScript support
 
 This plugin provides its own TS types. Just point your tsconfig to the type extensions like mentioned [here](https://webdriver.io/docs/typescript.html#framework-types):
@@ -189,7 +199,7 @@ This plugin provides its own TS types. Just point your tsconfig to the type exte
 
 ## Running the tests
 
-A recent version of Chrome is required to run the tests locally. You may need to update the `chromedriver` dependency to match the version installed on your system.
+Recent versions of Chrome and Firefox are required to run the tests locally. You may need to update the `chromedriver` and `geckodriver` dependencies to match the version installed on your system.
 
 ```shell
 npm test

--- a/README.md
+++ b/README.md
@@ -112,6 +112,15 @@ It should work with somewhat newer versions of all browsers. Please report an is
 
 ## API
 
+Consult the TypeScript declaration file for the the full syntax of the custom commands added to the WebdriverIO browser object. In general, any method that takes an "options" object as a parameter can be called without that parameter to obtain the default behavior. These "optional options" objects are followed by `?: = {}` and the default values inferred are described for each method.
+
+### Option Descriptions
+
+This library offers a small amount of configuration when issuing commands. Configuration options that are used by multiple methods are described here (see each method definition to determine specific support).
+
+* `orderBy` (`'START' | 'END'`): This option controls the ordering of requests captured by the interceptor, when returned to your test. For backwards compatibility with existing versions of this library, the default ordering is `'END'`, which corresponds to when the request was completed. If you set the `orderBy` option to `'START'`, then the requests will be ordered according to the time that they were started.
+* `includePending` (`boolean`): This option controls whether not-yet-completed requests will be returned. For backwards compatibility with existing versions of this library, the default value is `false`, and only completed requests will be returned.
+
 ### browser.setupInterceptor()
 
 Captures ajax calls in the browser. You always have to call the setup function in order to assess requests later.
@@ -132,24 +141,25 @@ Helper method. Returns all the expectations you've made up until that point
 
 Helper method. Resets all the expectations you've made up until that point
 
-### browser.assertRequests({ orderBy?: 'START' | 'END' })
+### browser.assertRequests({ orderBy?: 'START' | 'END' }?: = {})
 
 Call this method when all expected ajax requests are finished. It compares the expectations to the actual requests made and asserts the following:
 
 - Count of the requests that were made
-- The order of the requests (defaults to `orderBy: 'END'`, i.e. when the requests were completed)
+- The order of the requests
 - The method, the URL and the statusCode should match for every request made
+- The options object defaults to `{ orderBy: 'END' }`, i.e. when the requests were completed, to be consistent with the behavior of v4.1.10 and earlier. When the `orderBy` option is set to `'START'`, the requests will be ordered by when they were initiated by the page.
 
-### browser.assertExpectedRequestsOnly({ inOrder?: boolean, orderBy?: 'START' | 'END' })
+### browser.assertExpectedRequestsOnly({ inOrder?: boolean, orderBy?: 'START' | 'END' }?: = {})
 
 Similar to `browser.assertRequests`, but validates only the requests you specify in your `expectRequest` directives, without having to map out all the network requests that might happen around that. If `inOrder` option is `true` (default), the requests are expected to be found in the same order as they were setup with `expectRequest`.
 
-### browser.getRequest(index: number, { includePending?: boolean, orderBy?: 'START' | 'END' })
+### browser.getRequest(index: number, { includePending?: boolean, orderBy?: 'START' | 'END' }?: = {})
 
 To make more sophisticated assertions about a specific request you can get details for a specific request. You have to provide the 0-based index of the request you want to access, in the order the requests were completed (default), or initiated (by passing the `orderBy: 'START'` option).
 
-* `index` (`Number`): number of the request you want to access
-* `options` (`object`): Request options
+* `index` (`number`): number of the request you want to access
+* `options` (`object`): Configuration options
 * `options.includePending` (`boolean`): Whether not-yet-completed requests should be returned. By default, this is false, to match the behavior of the library in v4.1.10 and earlier.
 * `options.orderBy` (`'START' | 'END'`): How the requests should be ordered. By default, this is `'END'`, to match the behavior of the library in v4.1.10 and earlier. If `'START'`, the requests will be ordered by the time of initiation, rather than the time of request completion. (Since a pending request has not yet completed, when ordering by `'END'` all pending requests will come after all completed requests.)
 
@@ -160,6 +170,7 @@ To make more sophisticated assertions about a specific request you can get detai
 * `request.body`: payload/body data used in request
 * `request.headers`: request http headers as JS object
 * `request.pending`: boolean flag for whether this request is complete (i.e. has a `response` property), or in-flight.
+* `request.response`: a JS object that is only present if the request is completed (i.e. `request.pending === false`), containing data about the response.
 * `request.response?.headers`: response http headers as JS object
 * `request.response?.body`: response body (will be parsed as JSON if possible)
 * `request.response?.statusCode`: response status code
@@ -174,7 +185,7 @@ To make more sophisticated assertions about a specific request you can get detai
 
 **For the `fetch` API, we only support string and JSON data!**
 
-### browser.getRequests(options)
+### browser.getRequests({ includePending?: boolean, orderBy?: 'START' | 'END' }?: = {})
 
 Get all captured requests as an array, supporting the same optional options as `getRequest`.
 

--- a/README.md
+++ b/README.md
@@ -176,16 +176,16 @@ To make more sophisticated assertions about a specific request you can get detai
 
 ### browser.getRequests(options)
 
-Get all captured requests as an array, supporting the same options as `getRequest`.
+Get all captured requests as an array, supporting the same optional options as `getRequest`.
 
 **Returns** array of `request` objects.
-
 
 ### browser.hasPendingRequests()
 
 A utility method that checks whether any HTTP requests are still pending. Can be used by tests to ensure all requests have completed within a reasonable amount of time, or to verify that a call to `getRequests()` or `assertRequests()` will include all of the desired HTTP requests.
 
 **Returns** boolean
+
 ## TypeScript support
 
 This plugin provides its own TS types. Just point your tsconfig to the type extensions like mentioned [here](https://webdriver.io/docs/typescript.html#framework-types):

--- a/index.js
+++ b/index.js
@@ -34,6 +34,7 @@ class WebdriverAjax {
       'assertExpectedRequestsOnly',
       assertExpectedRequestsOnly.bind(this)
     );
+    browser.addCommand('hasPendingRequests', hasPendingRequests);
     browser.addCommand('getRequest', getRequest);
     browser.addCommand('getRequests', getRequest);
 
@@ -237,6 +238,11 @@ class WebdriverAjax {
         return mapIndexed(request, transformRequest);
       }
       return transformRequest(request);
+    }
+
+    async function hasPendingRequests() {
+      const requests = await this.getRequest();
+      return requests.some((r) => r.pending === true);
     }
 
     function transformRequest(req) {

--- a/index.js
+++ b/index.js
@@ -1,11 +1,17 @@
 'use strict';
 
 const interceptor = require('./lib/interceptor');
+const PKG_PREFIX = '[wdio-intercept-service]: ';
+class InterceptServiceError extends Error {
+  constructor(message, ...args) {
+    super(PKG_PREFIX + message, ...args);
+  }
+}
 
 const issueDeprecation = (map, key, what) => {
   if (!map[key]) {
     console.warn(
-      `[wdio-intercept-service]: ${what} is deprecated and will no longer work in v5`
+      `${PKG_PREFIX}${what} is deprecated and will no longer work in v5`
     );
     map[key] = true;
   }
@@ -72,8 +78,8 @@ class WebdriverAjax {
 
       // Don't let users request pending requests:
       if (options.includePending) {
-        throw new Error(
-          '[wdio-intercept-service]: passing `includePending` option to `assertRequests` is not supported!'
+        throw new InterceptServiceError(
+          'passing `includePending` option to `assertRequests` is not supported!'
         );
       }
       return getRequests(options).then((requests) => {
@@ -172,8 +178,8 @@ class WebdriverAjax {
 
       // Don't let users request pending requests:
       if (options.includePending) {
-        throw new Error(
-          '[wdio-intercept-service]: passing `includePending` option to `assertExpectedRequestsOnly` is not supported!'
+        throw new InterceptServiceError(
+          'passing `includePending` option to `assertExpectedRequestsOnly` is not supported!'
         );
       }
       return getRequests(options).then((requests) => {

--- a/index.js
+++ b/index.js
@@ -36,7 +36,7 @@ class WebdriverAjax {
     );
     browser.addCommand('hasPendingRequests', hasPendingRequests);
     browser.addCommand('getRequest', getRequest);
-    browser.addCommand('getRequests', getRequest);
+    browser.addCommand('getRequests', getRequests);
 
     function setup() {
       return browser.executeAsync(interceptor.setup);
@@ -59,7 +59,7 @@ class WebdriverAjax {
           new Error('No expectations found. Call .expectRequest() first')
         );
       }
-      return getRequest().then((requests) => {
+      return getRequests().then((requests) => {
         if (expectations.length !== requests.length) {
           return Promise.reject(
             new Error(
@@ -139,7 +139,7 @@ class WebdriverAjax {
     function assertExpectedRequestsOnly(inOrder = true) {
       const expectations = this._wdajaxExpectations;
 
-      return getRequest().then((requests) => {
+      return getRequests().then((requests) => {
         const clonedRequests = [...requests];
 
         let matchedRequestIndexes = [];
@@ -215,13 +215,16 @@ class WebdriverAjax {
       return this._wdajaxExpectations;
     }
 
-    async function getRequest(index) {
-      let request;
-      if (index > -1) {
-        request = await browser.execute(interceptor.getRequest, index);
-      } else {
-        request = await browser.execute(interceptor.getRequest);
-      }
+    function getRequests(options = {}) {
+      return getRequest(undefined, options);
+    }
+
+    async function getRequest(index, options = {}) {
+      const request = await browser.execute(
+        interceptor.getRequest,
+        index > -1 ? index : undefined,
+        options
+      );
       if (!request) {
         if (index != null) {
           return Promise.reject(
@@ -241,7 +244,7 @@ class WebdriverAjax {
     }
 
     async function hasPendingRequests() {
-      const requests = await this.getRequest();
+      const requests = await this.getRequests({ includePending: true });
       return requests.some((r) => r.pending === true);
     }
 

--- a/index.js
+++ b/index.js
@@ -250,17 +250,26 @@ class WebdriverAjax {
         return;
       }
 
-      return {
+      const transformed = {
         url: req.url,
         method: req.method && req.method.toUpperCase(),
-        body: parseBody(req.requestBody),
         headers: normalizeRequestHeaders(req.requestHeaders),
-        response: {
+        body: parseBody(req.requestBody),
+        pending: true,
+      };
+      // Check for a '__fulfilled' property on the retrieved request, which is
+      // set by the interceptor only when the response completes. Before this
+      // flag is set, the request is still being processed (e.g. a large response
+      // body is downloading) and therefore is pending.
+      if (req.__fulfilled) {
+        transformed.pending = false;
+        transformed.response = {
           headers: parseResponseHeaders(req.headers),
           body: parseBody(req.body),
           statusCode: req.statusCode,
-        },
-      };
+        };
+      }
+      return transformed;
     }
 
     function normalizeRequestHeaders(headers) {

--- a/index.js
+++ b/index.js
@@ -243,9 +243,8 @@ class WebdriverAjax {
       return transformRequest(request);
     }
 
-    async function hasPendingRequests() {
-      const requests = await this.getRequests({ includePending: true });
-      return requests.some((r) => r.pending === true);
+    function hasPendingRequests() {
+      return browser.execute(interceptor.hasPending);
     }
 
     function transformRequest(req) {

--- a/lib/interceptor.js
+++ b/lib/interceptor.js
@@ -202,7 +202,7 @@ var interceptor = {
     }
 
     function addPendingRequest(startedRequest) {
-      startedRequest.__processed = new Date().getTime();
+      startedRequest.__processed = Date.now();
       window[NAMESPACE].requests.push(startedRequest);
       pushToSessionStorage(startedRequest);
     }
@@ -213,14 +213,14 @@ var interceptor = {
       startedRequest.body = completedRequest.body;
       startedRequest.headers = completedRequest.headers;
       startedRequest.statusCode = completedRequest.statusCode;
-      startedRequest.__fulfilled = true;
+      startedRequest.__fulfilled = Date.now();
       replaceInSessionStorage(startedRequest);
     }
 
     function completeXHRRequest(startedRequest, responseBody) {
       // Merge the completed data with the started request.
       startedRequest.body = responseBody;
-      startedRequest.__fulfilled = true;
+      startedRequest.__fulfilled = Date.now();
       replaceInSessionStorage(startedRequest);
     }
 
@@ -315,18 +315,34 @@ var interceptor = {
       return parsed;
     }
     function getAllRequests() {
+      // Session storage will always return an array that can be mutated freely.
       if (window.sessionStorage && window.sessionStorage.getItem) {
         return getFromSessionStorage() || [];
       }
-      return window[NAMESPACE].requests || [];
+      // But if we have to use the active namespace array, then return a copy of it.
+      var shouldClone = window[NAMESPACE].requests;
+      return shouldClone ? shouldClone.slice() : [];
+    }
+    function isComplete(r) {
+      return typeof r.__fulfilled === 'number';
     }
 
     var requests = getAllRequests();
-    var includePending = Boolean(options.includePending);
-    var isComplete = function (rq) {
-      return rq.__fulfilled;
-    };
 
+    var shouldSortByEnd = String(options.orderBy).toUpperCase() !== 'START';
+    if (shouldSortByEnd) {
+      // Sort ascending by time of fulfillment. If not fulfilled yet, sort to the end!
+      requests.sort(function (a, b) {
+        var hasA = isComplete(a);
+        var hasB = isComplete(b);
+        if (hasA && hasB) return a.__fulfilled - b.__fulfilled;
+        if (hasA) return -1; // Only A is fulfilled, so order A before B
+        if (hasB) return 1; // Only B is fulfilled, so order A after B
+        return 0; // Preserve ordering of A & B.
+      });
+    }
+
+    var includePending = Boolean(options.includePending);
     if (index == null) {
       return includePending ? requests : requests.filter(isComplete);
     }

--- a/lib/interceptor.js
+++ b/lib/interceptor.js
@@ -3,6 +3,7 @@
 var interceptor = {
   setup: function setup(done) {
     var NAMESPACE = '__webdriverajax';
+    var PKG_PREFIX = '[wdio-intercept-service]: ';
 
     window[NAMESPACE] = { requests: [] };
 
@@ -21,9 +22,7 @@ var interceptor = {
         typeof window.Promise === 'undefined' ||
         typeof window.Promise.all !== 'function'
       ) {
-        console.error(
-          '[wdio-intercept-service]: Fetch API preconditions not met!'
-        );
+        console.error(PKG_PREFIX + 'Fetch API preconditions not met!');
       }
     }
 
@@ -56,9 +55,7 @@ var interceptor = {
             request.requestHeaders = parseHeaders(clonedRequest.headers);
             request.method = clonedRequest.method;
           } else {
-            console.error(
-              '[wdio-intercept-service]: Unhandled input type to fetch API!'
-            );
+            console.error(PKG_PREFIX + 'Unhandled input type to fetch API!');
             request.requestBody = input.body;
           }
         }
@@ -193,10 +190,7 @@ var interceptor = {
       try {
         return JSON.stringify(payload);
       } catch (e) {
-        console.error(
-          '[wdio-intercept-service]: Failed to stringify payload as JSON!',
-          e
-        );
+        console.error(PKG_PREFIX + 'Failed to stringify payload as JSON!', e);
       }
       return '';
     }
@@ -233,8 +227,7 @@ var interceptor = {
         return JSON.parse(rawData);
       } catch (e) {
         throw new Error(
-          '[wdio-intercept-service]: Could not parse sessionStorage data: ' +
-            e.message
+          PKG_PREFIX + 'Could not parse sessionStorage data: ' + e.message
         );
       }
     }
@@ -298,6 +291,7 @@ var interceptor = {
   },
   getRequest: function getRequest(index, options) {
     var NAMESPACE = '__webdriverajax';
+    var PKG_PREFIX = '[wdio-intercept-service]: ';
 
     function getFromSessionStorage() {
       var rawData = window.sessionStorage.getItem(NAMESPACE);
@@ -307,8 +301,7 @@ var interceptor = {
           parsed = JSON.parse(rawData);
         } catch (e) {
           throw new Error(
-            '[wdio-intercept-service]: Could not parse sessionStorage data: ' +
-              e.message
+            PKG_PREFIX + 'Could not parse sessionStorage data: ' + e.message
           );
         }
       }

--- a/lib/interceptor.js
+++ b/lib/interceptor.js
@@ -163,29 +163,35 @@ var interceptor = {
       return headers || {};
     }
 
+    /**
+     * Stringify the given XHR payload so it can be parsed as JSON
+     * @param {*} payload XHR request body that is sent to the remote server.
+     * @returns {string} JSON-parsable representation of the request body
+     */
     function parsePayload(payload) {
-      var parsed;
       if (typeof payload == 'string') {
-        parsed = payload;
-      } else if (payload instanceof FormData) {
-        parsed = {};
+        return payload;
+      }
+      if (payload instanceof FormData) {
+        var parsed = {};
         var entries = payload.entries();
         var item;
         while (((item = entries.next()), !item.done)) {
           parsed[item.value[0]] = item.value.slice(1);
         }
-        parsed = JSON.stringify(parsed);
-      } else if (payload instanceof ArrayBuffer) {
-        parsed = String.fromCharCode.apply(null, payload);
-      } else {
-        // Just try to convert it to a string, whatever it might be
-        try {
-          parsed = JSON.stringify(payload);
-        } catch (e) {
-          parsed = '';
-        }
+        return JSON.stringify(parsed);
       }
-      return parsed;
+      if (payload instanceof ArrayBuffer) {
+        return String.fromCharCode.apply(null, payload);
+      }
+
+      // Just try to convert it to a string, whatever it might be
+      try {
+        return JSON.stringify(payload);
+      } catch (e) {
+        console.error('Failed to stringify payload as JSON!', e);
+      }
+      return '';
     }
 
     function addPendingRequest(startedRequest) {

--- a/lib/interceptor.js
+++ b/lib/interceptor.js
@@ -21,7 +21,9 @@ var interceptor = {
         typeof window.Promise === 'undefined' ||
         typeof window.Promise.all !== 'function'
       ) {
-        console.error('wdio-intercept-service preconditions not met!');
+        console.error(
+          '[wdio-intercept-service]: Fetch API preconditions not met!'
+        );
       }
     }
 
@@ -54,7 +56,9 @@ var interceptor = {
             request.requestHeaders = parseHeaders(clonedRequest.headers);
             request.method = clonedRequest.method;
           } else {
-            console.error('Unhandled input type to fetch API!');
+            console.error(
+              '[wdio-intercept-service]: Unhandled input type to fetch API!'
+            );
             request.requestBody = input.body;
           }
         }
@@ -189,7 +193,10 @@ var interceptor = {
       try {
         return JSON.stringify(payload);
       } catch (e) {
-        console.error('Failed to stringify payload as JSON!', e);
+        console.error(
+          '[wdio-intercept-service]: Failed to stringify payload as JSON!',
+          e
+        );
       }
       return '';
     }
@@ -225,7 +232,10 @@ var interceptor = {
       try {
         return JSON.parse(rawData);
       } catch (e) {
-        throw new Error('Could not parse sessionStorage data: ' + e.message);
+        throw new Error(
+          '[wdio-intercept-service]: Could not parse sessionStorage data: ' +
+            e.message
+        );
       }
     }
 
@@ -304,7 +314,10 @@ var interceptor = {
         try {
           parsed = JSON.parse(rawData);
         } catch (e) {
-          throw new Error('Could not parse sessionStorage data: ' + e.message);
+          throw new Error(
+            '[wdio-intercept-service]: Could not parse sessionStorage data: ' +
+              e.message
+          );
         }
       }
       return parsed;

--- a/lib/interceptor.js
+++ b/lib/interceptor.js
@@ -77,6 +77,7 @@ var interceptor = {
             request.body = results[1];
             request.statusCode = clonedResponse.status;
             request.headers = parseHeaders(clonedResponse.headers);
+            request.__fulfilled = true;
             addRequest(request);
           });
           return response;
@@ -111,6 +112,7 @@ var interceptor = {
           var parsed = parseBody(_this, req);
           if (!parsed.deferred) {
             req.body = parsed.body;
+            req.__fulfilled = true;
             addRequest(req);
           }
         });
@@ -134,6 +136,7 @@ var interceptor = {
         var fr = new FileReader();
         fr.addEventListener('load', function () {
           request.body = new TextDecoder().decode(this.result);
+          request.__fulfilled = true;
           addRequest(request);
         });
         fr.readAsArrayBuffer(xhr.response);

--- a/lib/interceptor.js
+++ b/lib/interceptor.js
@@ -63,7 +63,7 @@ var interceptor = {
           if (typeof init.method !== 'undefined') request.method = init.method;
           request.requestHeaders = parseHeaders(init.headers);
         }
-        addPendingFetchRequest(request);
+        addPendingRequest(request);
 
         return _fetch.apply(window, arguments).then(function (response) {
           // TODO: We could clone it multiple times and check for all type variations of body
@@ -80,7 +80,6 @@ var interceptor = {
               body: results[1],
               statusCode: clonedResponse.status,
               headers: parseHeaders(clonedResponse.headers),
-              __fulfilled: true,
             });
           });
 
@@ -100,25 +99,23 @@ var interceptor = {
         originalOpen.apply(this, arguments);
       };
       XMLHttpRequest.prototype.send = function () {
-        this.lastRequestBody = parsePayload(arguments[0]);
+        var req = {
+          method: this.lastMethod.toUpperCase(),
+          requestHeaders: this.lastRequestHeader || {},
+          requestBody: parsePayload(arguments[0]),
+          url: this.lastURL.toString(),
+        };
+        addPendingRequest(req);
         originalSend.apply(this, arguments);
 
         var _this = this;
         this.addEventListener('load', function () {
-          var req = {
-            url: _this.lastURL,
-            method: _this.lastMethod.toUpperCase(),
-            headers: _this.getAllResponseHeaders(),
-            requestHeaders: _this.lastRequestHeader || {},
-            statusCode: _this.status,
-            requestBody: _this.lastRequestBody,
-          };
+          req.statusCode = _this.status;
+          req.headers = _this.getAllResponseHeaders();
           // The body may need to be further processed, or may be ready synchronously.
           var parsed = parseBody(_this, req);
           if (!parsed.deferred) {
-            req.body = parsed.body;
-            req.__fulfilled = true;
-            addRequest(req);
+            completeXHRRequest(req, parsed.body);
           }
         });
       };
@@ -140,9 +137,7 @@ var interceptor = {
         // Read the response like a file.
         var fr = new FileReader();
         fr.addEventListener('load', function () {
-          request.body = new TextDecoder().decode(this.result);
-          request.__fulfilled = true;
-          addRequest(request);
+          completeXHRRequest(request, new TextDecoder().decode(this.result));
         });
         fr.readAsArrayBuffer(xhr.response);
         return { deferred: true };
@@ -193,7 +188,7 @@ var interceptor = {
       return parsed;
     }
 
-    function addPendingFetchRequest(startedRequest) {
+    function addPendingRequest(startedRequest) {
       startedRequest.__processed = new Date().getTime();
       window[NAMESPACE].requests.push(startedRequest);
       pushToSessionStorage(startedRequest);
@@ -209,9 +204,11 @@ var interceptor = {
       replaceInSessionStorage(startedRequest);
     }
 
-    function addRequest(request) {
-      window[NAMESPACE].requests.push(request);
-      pushToSessionStorage(request);
+    function completeXHRRequest(startedRequest, responseBody) {
+      // Merge the completed data with the started request.
+      startedRequest.body = responseBody;
+      startedRequest.__fulfilled = true;
+      replaceInSessionStorage(startedRequest);
     }
 
     function getParsedSessionStorage() {

--- a/lib/interceptor.js
+++ b/lib/interceptor.js
@@ -11,12 +11,18 @@ var interceptor = {
       polyfillFormDataEntries();
     }
 
-    if (window.sessionStorage && window.sessionStorage.removeItem) {
+    if (supportsSessionStorage()) {
       window.sessionStorage.removeItem(NAMESPACE);
     }
 
     if (typeof window.fetch == 'function') {
       replaceFetch();
+      if (
+        typeof window.Promise === 'undefined' ||
+        typeof window.Promise.all !== 'function'
+      ) {
+        console.error('wdio-intercept-service preconditions not met!');
+      }
     }
 
     replaceXHR();
@@ -184,21 +190,32 @@ var interceptor = {
       pushToSessionStorage(request);
     }
 
+    function getParsedSessionStorage() {
+      var rawData = window.sessionStorage.getItem(NAMESPACE);
+      if (!rawData) {
+        return [];
+      }
+      try {
+        return JSON.parse(rawData);
+      } catch (e) {
+        throw new Error('Could not parse sessionStorage data: ' + e.message);
+      }
+    }
+
+    function supportsSessionStorage() {
+      return (
+        typeof window.sessionStorage === 'object' &&
+        window.sessionStorage !== null &&
+        typeof window.sessionStorage.setItem === 'function' &&
+        typeof window.sessionStorage.removeItem === 'function'
+      );
+    }
+
     function pushToSessionStorage(req) {
-      if (!window.sessionStorage || !window.sessionStorage.setItem) {
+      if (!supportsSessionStorage()) {
         return;
       }
-      var rawData = window.sessionStorage.getItem(NAMESPACE);
-      var parsed;
-      if (rawData) {
-        try {
-          parsed = JSON.parse(rawData);
-        } catch (e) {
-          throw new Error('Could not parse sessionStorage data: ' + e.message);
-        }
-      } else {
-        parsed = [];
-      }
+      var parsed = getParsedSessionStorage();
       parsed.push(req);
       window.sessionStorage.setItem(NAMESPACE, JSON.stringify(parsed));
     }

--- a/lib/interceptor.js
+++ b/lib/interceptor.js
@@ -353,6 +353,19 @@ var interceptor = {
     }
     return requests[index];
   },
+
+  /**
+   * Convenience method that avoids needing to marshall all requests between node & the browser,
+   * and instead inspects the active namespace request array for any unfulfilled requests.
+   */
+  hasPending: function hasPending() {
+    var NAMESPACE = '__webdriverajax';
+    var allRequests = window[NAMESPACE].requests || [];
+    for (var idx = 0; idx < allRequests.length; ++idx) {
+      if (typeof allRequests[idx].__fulfilled === 'undefined') return true;
+    }
+    return false;
+  },
 };
 
 module.exports = interceptor;

--- a/lib/interceptor.js
+++ b/lib/interceptor.js
@@ -296,16 +296,8 @@ var interceptor = {
       };
     }
   },
-  getRequest: function getRequest(index) {
+  getRequest: function getRequest(index, options) {
     var NAMESPACE = '__webdriverajax';
-
-    var requests;
-
-    if (window.sessionStorage && window.sessionStorage.getItem) {
-      requests = getFromSessionStorage() || [];
-    } else {
-      requests = window[NAMESPACE].requests || [];
-    }
 
     function getFromSessionStorage() {
       var rawData = window.sessionStorage.getItem(NAMESPACE);
@@ -322,11 +314,27 @@ var interceptor = {
       }
       return parsed;
     }
-
-    if (index == null) {
-      return requests;
+    function getAllRequests() {
+      if (window.sessionStorage && window.sessionStorage.getItem) {
+        return getFromSessionStorage() || [];
+      }
+      return window[NAMESPACE].requests || [];
     }
 
+    var requests = getAllRequests();
+    var includePending = Boolean(options.includePending);
+    var isComplete = function (rq) {
+      return rq.__fulfilled;
+    };
+
+    if (index == null) {
+      return includePending ? requests : requests.filter(isComplete);
+    }
+
+    if (!includePending) {
+      // Filter out the pending requests and index only into the completed requests.
+      return requests.filter(isComplete)[index];
+    }
     return requests[index];
   },
 };

--- a/lib/interceptor.js
+++ b/lib/interceptor.js
@@ -38,7 +38,6 @@ var interceptor = {
           requestHeaders: {},
           requestBody: undefined,
           url: '',
-          headers: {},
         };
         var input = arguments[0];
         var init = arguments[1];
@@ -64,22 +63,28 @@ var interceptor = {
           if (typeof init.method !== 'undefined') request.method = init.method;
           request.requestHeaders = parseHeaders(init.headers);
         }
+        addPendingFetchRequest(request);
 
         return _fetch.apply(window, arguments).then(function (response) {
           // TODO: We could clone it multiple times and check for all type variations of body
           var clonedResponse = response.clone();
           var responsePromise = clonedResponse.text();
 
+          // After decoding the request's body (which may have come from Request#text())
+          // and the response body, we can store the completed request.
           Promise.all([request.requestBody, responsePromise]).then(function (
             results
           ) {
-            request.requestBody = results[0];
-            request.body = results[1];
-            request.statusCode = clonedResponse.status;
-            request.headers = parseHeaders(clonedResponse.headers);
-            request.__fulfilled = true;
-            addRequest(request);
+            completeFetchRequest(request, {
+              requestBody: results[0],
+              body: results[1],
+              statusCode: clonedResponse.status,
+              headers: parseHeaders(clonedResponse.headers),
+              __fulfilled: true,
+            });
           });
+
+          // Forward the original response to the application on the current tick.
           return response;
         });
       };
@@ -188,6 +193,22 @@ var interceptor = {
       return parsed;
     }
 
+    function addPendingFetchRequest(startedRequest) {
+      startedRequest.__processed = new Date().getTime();
+      window[NAMESPACE].requests.push(startedRequest);
+      pushToSessionStorage(startedRequest);
+    }
+
+    function completeFetchRequest(startedRequest, completedRequest) {
+      // Merge the completed data with the started request.
+      startedRequest.requestBody = completedRequest.requestBody;
+      startedRequest.body = completedRequest.body;
+      startedRequest.headers = completedRequest.headers;
+      startedRequest.statusCode = completedRequest.statusCode;
+      startedRequest.__fulfilled = true;
+      replaceInSessionStorage(startedRequest);
+    }
+
     function addRequest(request) {
       window[NAMESPACE].requests.push(request);
       pushToSessionStorage(request);
@@ -220,6 +241,33 @@ var interceptor = {
       }
       var parsed = getParsedSessionStorage();
       parsed.push(req);
+      window.sessionStorage.setItem(NAMESPACE, JSON.stringify(parsed));
+    }
+
+    function replaceInSessionStorage(completedRequest) {
+      if (!supportsSessionStorage()) {
+        return;
+      }
+      var parsed = getParsedSessionStorage();
+      // Unlike requests held in the namespace, no session-stored requests can share object equality
+      // with the completed request, due to the string serialization. Instead, we must look for an
+      // item with the same "__processed" time. In case multiple requests are added simultaneously,
+      // the url and method are used to further disambiguate the serialized requests.
+      for (
+        var storedRqNumber = 0;
+        storedRqNumber < parsed.length;
+        ++storedRqNumber
+      ) {
+        var r = parsed[storedRqNumber];
+        if (
+          r.__processed === completedRequest.__processed &&
+          r.url === completedRequest.url &&
+          r.method === completedRequest.method
+        ) {
+          parsed[storedRqNumber] = completedRequest;
+          break;
+        }
+      }
       window.sessionStorage.setItem(NAMESPACE, JSON.stringify(parsed));
     }
 

--- a/test/site/pending.html
+++ b/test/site/pending.html
@@ -22,25 +22,25 @@
 
       document.querySelector('#fast').addEventListener('click', function (evt) {
         var xhr = new XMLHttpRequest();
-        xhr.open('POST', '/post.json');
+        xhr.open('POST', '/post.json?type=xhr');
         xhr.addEventListener('load', () => update("Speedy XHR"));
         xhr.send('fast');
       });
 
       document.querySelector('#slow').addEventListener('click', function (evt) {
         var xhr = new XMLHttpRequest();
-        xhr.open('POST', '/post.json?slow=true');
+        xhr.open('POST', '/post.json?slow=true&type=xhr');
         xhr.addEventListener('load', () => update("Slow XHR"));
         xhr.send('slow');
       });
 
       document.querySelector('#fetchfast').addEventListener('click', function (evt) {
-        fetch('/post.json', { method: 'POST', body: 'fast' })
+        fetch('/post.json?type=fetch', { method: 'POST', body: 'fast' })
           .then(() => update("Fetched\n"));
       });
 
       document.querySelector('#fetchslow').addEventListener('click', function (evt) {
-        fetch('/post.json?slow=true', { method: 'POST', body: 'slow' })
+        fetch('/post.json?slow=true&type=fetch', { method: 'POST', body: 'slow' })
           .then(() => update("Fetched after a while\n"));
       });
 

--- a/test/site/pending.html
+++ b/test/site/pending.html
@@ -1,0 +1,50 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <title>Fast and Slow GETs</title>
+</head>
+<body>
+  <p id="text">This file makes various GET requests to /get.json</p>
+  <button id="instant">Press me</button>
+  <button id="slow">No, press me!</button>
+  <button id="fetchfast">Press me</button>
+  <button id="fetchslow">No, press me!</button>
+  <div id="response"></div>
+  <script>
+    'use strict';
+
+    (function (window, document) {
+      var update = function (msg) {
+        document.querySelector('#response').textContent += msg;
+      };
+
+      document.querySelector('#instant').addEventListener('click', function (evt) {
+        var xhr = new XMLHttpRequest();
+        xhr.open('POST', '/post.json');
+        xhr.addEventListener('load', () => update("Speedy XHR"));
+        xhr.send('fast');
+      });
+
+      document.querySelector('#slow').addEventListener('click', function (evt) {
+        var xhr = new XMLHttpRequest();
+        xhr.open('POST', '/post.json?slow=true');
+        xhr.addEventListener('load', () => update("Slow XHR"));
+        xhr.send('slow');
+      });
+
+      document.querySelector('#fetchfast').addEventListener('click', function (evt) {
+        fetch('/post.json', { method: 'POST', body: 'fast' })
+          .then(() => update("Fetched\n"));
+      });
+
+      document.querySelector('#fetchslow').addEventListener('click', function (evt) {
+        fetch('/post.json?slow=true', { method: 'POST', body: 'slow' })
+          .then(() => update("Fetched after a while\n"));
+      });
+
+    })(window, window.document);
+  </script>
+</body>
+</html>

--- a/test/site/pending.html
+++ b/test/site/pending.html
@@ -7,7 +7,7 @@
 </head>
 <body>
   <p id="text">This file makes various GET requests to /get.json</p>
-  <button id="instant">Press me</button>
+  <button id="fast">Press me</button>
   <button id="slow">No, press me!</button>
   <button id="fetchfast">Press me</button>
   <button id="fetchslow">No, press me!</button>
@@ -20,7 +20,7 @@
         document.querySelector('#response').textContent += msg;
       };
 
-      document.querySelector('#instant').addEventListener('click', function (evt) {
+      document.querySelector('#fast').addEventListener('click', function (evt) {
         var xhr = new XMLHttpRequest();
         xhr.open('POST', '/post.json');
         xhr.addEventListener('load', () => update("Speedy XHR"));

--- a/test/spec/plugin_test.js
+++ b/test/spec/plugin_test.js
@@ -100,7 +100,10 @@ describe('webdriverajax', function testSuite() {
       await browser.expectRequest('GET', '/get.json', 200);
       await browser.expectRequest('GET', '/get.json', 200);
       await completedRequest('#button');
-      assert.rejects(() => browser.assertRequests(), /Expected/);
+      await assert.rejects(
+        () => browser.assertRequests(),
+        /Expected 2 requests but was 1/
+      );
     });
 
     it('errors on wrong method', async function () {
@@ -108,7 +111,10 @@ describe('webdriverajax', function testSuite() {
       await browser.setupInterceptor();
       await browser.expectRequest('PUT', '/get.json', 200);
       await completedRequest('#button');
-      assert.rejects(() => browser.assertRequests(), /PUT/);
+      await assert.rejects(
+        () => browser.assertRequests(),
+        /method PUT but was GET/
+      );
     });
 
     it('errors on wrong URL', async function () {
@@ -116,7 +122,10 @@ describe('webdriverajax', function testSuite() {
       await browser.setupInterceptor();
       await browser.expectRequest('GET', '/wrong.json', 200);
       await completedRequest('#button');
-      assert.rejects(() => browser.assertRequests(), /wrong\.json/);
+      await assert.rejects(
+        () => browser.assertRequests(),
+        /to have URL \/wrong\.json but was/
+      );
     });
 
     it("errors if regex doesn't match URL", async function () {
@@ -124,7 +133,13 @@ describe('webdriverajax', function testSuite() {
       await browser.setupInterceptor();
       await browser.expectRequest('GET', /wrong\.json/, 200);
       await completedRequest('#button');
-      assert.rejects(() => browser.assertRequests(), /get\.json/);
+      await assert.rejects(
+        () => browser.assertRequests(),
+        (err) => {
+          assert.match(err.message, /to match \/wrong\\.json\/ but was/);
+          return true;
+        }
+      );
     });
 
     it('errors on wrong status code', async function () {
@@ -132,7 +147,10 @@ describe('webdriverajax', function testSuite() {
       await browser.setupInterceptor();
       await browser.expectRequest('GET', '/get.json', 404);
       await completedRequest('#button');
-      assert.rejects(() => browser.assertRequests(), /404/);
+      await assert.rejects(
+        () => browser.assertRequests(),
+        /status 404 but was 200/
+      );
     });
 
     it('can access a certain request', async function () {
@@ -237,7 +255,10 @@ describe('webdriverajax', function testSuite() {
     it('errors with no requests set up', async function () {
       await browser.url('/get.html');
       await browser.setupInterceptor();
-      assert.rejects(() => browser.assertRequests(), /No\sexpectations\sfound/);
+      await assert.rejects(
+        () => browser.assertRequests(),
+        /No\sexpectations\sfound/
+      );
     });
 
     it('returns an empty array for no captured requests', async function () {
@@ -258,7 +279,7 @@ describe('webdriverajax', function testSuite() {
       await completedRequest('#getbutton');
       await completedRequest('#postbutton');
       await browser.assertExpectedRequestsOnly();
-      assert.rejects(
+      await assert.rejects(
         () => browser.assertRequests(),
         /Expected\s\d\srequests\sbut\swas\s\d/
       );
@@ -275,7 +296,7 @@ describe('webdriverajax', function testSuite() {
       await completedRequest('#getbutton');
       await completedRequest('#postbutton');
       await browser.assertExpectedRequestsOnly(true);
-      assert.rejects(
+      await assert.rejects(
         () => browser.assertRequests(),
         /Expected\s\d\srequests\sbut\swas\s\d/
       );
@@ -291,7 +312,7 @@ describe('webdriverajax', function testSuite() {
       await completedRequest('#getbutton');
       await completedRequest('#getbutton');
       await browser.assertExpectedRequestsOnly(false);
-      assert.rejects(
+      await assert.rejects(
         () => browser.assertRequests(),
         /Expected\s\d\srequests\sbut\swas\s\d/
       );
@@ -304,7 +325,7 @@ describe('webdriverajax', function testSuite() {
       await browser.expectRequest('POST', '/invalid.json', 200);
       await completedRequest('#getbutton');
       await completedRequest('#postbutton');
-      assert.rejects(
+      await assert.rejects(
         () => browser.assertExpectedRequestsOnly(false),
         /Expected request was not found. method: POST url: \/invalid.json statusCode: 200/
       );

--- a/test/spec/plugin_test.js
+++ b/test/spec/plugin_test.js
@@ -399,9 +399,9 @@ describe('webdriverajax', function testSuite() {
       await browser.pause(wait);
     });
     [
-      { api: 'XHR', button: '#slow' },
-      { api: 'Fetch', button: '#fetchslow' },
-    ].forEach(({ api, button }) => {
+      { api: 'XHR', button: '#slow', fastButton: '#fast' },
+      { api: 'Fetch', button: '#fetchslow', fastButton: '#fetchfast' },
+    ].forEach(({ api, button, fastButton }) => {
       it(`can report pending ${api} requests`, async function () {
         await browser.url('/pending.html');
         await browser.setupInterceptor();
@@ -432,6 +432,34 @@ describe('webdriverajax', function testSuite() {
           await browser.hasPendingRequests(),
           false,
           'should be false after request completion'
+        );
+      });
+
+      it(`can ignore pending ${api} requests`, async function () {
+        await browser.url('/pending.html');
+        await browser.setupInterceptor();
+        // Initiate the slow request, then the fast request, and wait for the fast request to complete.
+        await $(button)
+          .click()
+          .then(() => completedRequest(fastButton));
+        const completedOnly = await browser.getRequests({
+          includePending: false,
+        });
+        assert.equal(
+          completedOnly.length,
+          1,
+          '"includePending: false" should ignore pending requests'
+        );
+        const request = completedOnly[0];
+        assert.equal(
+          request.pending,
+          false,
+          'should retrieve completed request only'
+        );
+        assert.notEqual(
+          typeof request.response,
+          'undefined',
+          'should retrieve completed request'
         );
       });
     });

--- a/test/spec/plugin_test.js
+++ b/test/spec/plugin_test.js
@@ -321,6 +321,17 @@ describe('webdriverajax', function testSuite() {
       assert.equal(request.response.headers['content-length'], contentLength);
       assert.deepEqual(request.response.body, { OK: true });
     });
+
+    it('can report pending requests', async function () {
+      await browser.url('/pending.html');
+      await browser.setupInterceptor();
+      await $('#slow').click();
+      const request = await browser.getRequest(0, { includePending: true });
+      assert.equal(request.method, 'POST');
+      assert.equal(request.url, '/post.json?slow=true');
+      assert.equal(typeof request.response, 'undefined');
+      assert.equal(request.pending, true);
+    });
   });
 
   describe('fetch API', async function () {
@@ -369,6 +380,17 @@ describe('webdriverajax', function testSuite() {
       const request = await browser.getRequest(0);
       assert.equal(request.headers['content-type'], 'application/json');
       assert.deepEqual(request.body, { foo: 'bar' });
+    });
+
+    it('can report pending requests', async function () {
+      await browser.url('/pending.html');
+      await browser.setupInterceptor();
+      await $('#fetchslow').click();
+      const request = await browser.getRequest(0, { includePending: true });
+      assert.equal(request.method, 'POST');
+      assert.equal(request.url, '/post.json?slow=true');
+      assert.equal(typeof request.response, 'undefined');
+      assert.equal(request.pending, true);
     });
   });
 });

--- a/test/wdio.conf.js
+++ b/test/wdio.conf.js
@@ -123,10 +123,15 @@ exports.config = {
       {
         folders: [{ mount: '/', path: `${__dirname}/site` }],
         middleware: [
+          // Use a simple middleware to respond to non-GET requests:
           {
             mount: '/',
             middleware: (req, res) => {
-              res.sendFile(`${__dirname}/site${req.path}`);
+              const delay = req.query.slow === 'true' ? 500 : 0;
+              setTimeout(
+                () => res.sendFile(`${__dirname}/site${req.path}`),
+                delay
+              );
             },
           },
         ],

--- a/test/wdio.conf.js
+++ b/test/wdio.conf.js
@@ -127,7 +127,7 @@ exports.config = {
           {
             mount: '/',
             middleware: (req, res) => {
-              const delay = req.query.slow === 'true' ? 500 : 0;
+              const delay = req.query.slow === 'true' ? 1000 : 0;
               setTimeout(
                 () => res.sendFile(`${__dirname}/site${req.path}`),
                 delay

--- a/types/wdio-intercept-service.d.ts
+++ b/types/wdio-intercept-service.d.ts
@@ -60,6 +60,7 @@ declare module WebdriverIO {
       url: string | RegExp,
       statusCode: number
     ) => AsyncSync<BrowserObject>;
+    hasPendingRequests(): AsyncSync<boolean>;
     assertRequests: () => AsyncSync<BrowserObject>;
     assertExpectedRequestsOnly: (inOrder?: boolean) => AsyncSync<BrowserObject>;
     resetExpectations: () => AsyncSync<BrowserObject>;

--- a/types/wdio-intercept-service.d.ts
+++ b/types/wdio-intercept-service.d.ts
@@ -19,11 +19,12 @@ declare namespace WdioInterceptorService {
   interface InterceptedRequest {
     url: string;
     method: HTTPMethod;
-    body: string | object;
+    body: string | null | object;
+    pending: false;
     headers: object;
     response: {
       headers: object;
-      body: string | object;
+      body: string | null | object;
       statusCode: number;
     };
   }

--- a/types/wdio-intercept-service.d.ts
+++ b/types/wdio-intercept-service.d.ts
@@ -48,23 +48,23 @@ declare namespace WdioInterceptorService {
 /**
  * Convert T to T or Promise<T> depending if `@wdio/sync` is being used or not.
  */
-type AsyncSync<T> = WebdriverIO.BrowserObject extends WebDriver.Client
+type AsyncSync<T> = WebdriverIO.Browser extends WebDriver.Client
   ? T
   : Promise<T>;
 
 declare module WebdriverIO {
   interface Browser {
-    setupInterceptor: () => AsyncSync<void>;
-    expectRequest: (
+    setupInterceptor(): AsyncSync<void>;
+    expectRequest(
       method: WdioInterceptorService.HTTPMethod,
       url: string | RegExp,
       statusCode: number
-    ) => AsyncSync<BrowserObject>;
+    ): AsyncSync<Browser>;
     hasPendingRequests(): AsyncSync<boolean>;
-    assertRequests: () => AsyncSync<BrowserObject>;
-    assertExpectedRequestsOnly: (inOrder?: boolean) => AsyncSync<BrowserObject>;
-    resetExpectations: () => AsyncSync<BrowserObject>;
-    getExpectations: () => AsyncSync<WdioInterceptorService.ExpectedRequest[]>;
+    assertRequests(): AsyncSync<Browser>;
+    assertExpectedRequestsOnly(inOrder?: boolean): AsyncSync<Browser>;
+    resetExpectations(): AsyncSync<Browser>;
+    getExpectations(): AsyncSync<WdioInterceptorService.ExpectedRequest[]>;
     getRequest(
       index: number,
       options?: WdioInterceptorService.GetRequestOptions &

--- a/types/wdio-intercept-service.d.ts
+++ b/types/wdio-intercept-service.d.ts
@@ -39,13 +39,19 @@ declare namespace WdioInterceptorService {
 
   type InterceptedRequest = PendingRequest | CompletedRequest;
 
-  interface GetRequestOptions {
-    /** Whether pending requests will be included in the response */
-    includePending?: boolean;
+  interface OrderingStrategy {
     /** Whether requests are ordered by time of initiation, or fulfillment */
     orderBy?: 'START' | 'END';
   }
+  interface AssertionRequestOrderStrategy extends OrderingStrategy {
+    /** Whether the intercepted request order must match the order in which expectations were set */
+    inOrder?: boolean;
+  }
 
+  interface GetRequestOptions extends OrderingStrategy {
+    /** Whether pending requests will be included in the response */
+    includePending?: boolean;
+  }
   type OnlyCompletedRequests = { includePending: false };
 }
 /**
@@ -64,8 +70,13 @@ declare module WebdriverIO {
       statusCode: number
     ): AsyncSync<Browser>;
     hasPendingRequests(): AsyncSync<boolean>;
-    assertRequests(): AsyncSync<Browser>;
+    assertRequests(
+      options?: WdioInterceptorService.OrderingStrategy
+    ): AsyncSync<Browser>;
     assertExpectedRequestsOnly(inOrder?: boolean): AsyncSync<Browser>;
+    assertExpectedRequestsOnly(
+      options?: WdioInterceptorService.AssertionRequestOrderStrategy
+    ): AsyncSync<Browser>;
     resetExpectations(): AsyncSync<Browser>;
     getExpectations(): AsyncSync<WdioInterceptorService.ExpectedRequest[]>;
     getRequest(

--- a/types/wdio-intercept-service.d.ts
+++ b/types/wdio-intercept-service.d.ts
@@ -40,7 +40,10 @@ declare namespace WdioInterceptorService {
   type InterceptedRequest = PendingRequest | CompletedRequest;
 
   interface GetRequestOptions {
+    /** Whether pending requests will be included in the response */
     includePending?: boolean;
+    /** Whether requests are ordered by time of initiation, or fulfillment */
+    orderBy?: 'START' | 'END';
   }
 
   type OnlyCompletedRequests = { includePending: false };

--- a/types/wdio-intercept-service.d.ts
+++ b/types/wdio-intercept-service.d.ts
@@ -16,7 +16,15 @@ declare namespace WdioInterceptorService {
     statusCode: number;
   }
 
-  interface InterceptedRequest {
+  interface PendingRequest {
+    url: string;
+    method: HTTPMethod;
+    body: string | null | object;
+    headers: object;
+    pending: true;
+  }
+
+  interface CompletedRequest {
     url: string;
     method: HTTPMethod;
     body: string | null | object;
@@ -28,6 +36,14 @@ declare namespace WdioInterceptorService {
       statusCode: number;
     };
   }
+
+  type InterceptedRequest = PendingRequest | CompletedRequest;
+
+  interface GetRequestOptions {
+    includePending?: boolean;
+  }
+
+  type OnlyCompletedRequests = { includePending: false };
 }
 /**
  * Convert T to T or Promise<T> depending if `@wdio/sync` is being used or not.
@@ -47,13 +63,23 @@ declare module WebdriverIO {
     assertRequests: () => AsyncSync<BrowserObject>;
     assertExpectedRequestsOnly: (inOrder?: boolean) => AsyncSync<BrowserObject>;
     resetExpectations: () => AsyncSync<BrowserObject>;
-    getExpectations: () => AsyncSync<
-      WdioInterceptorService.ExpectedRequest[]
-    >;
-    getRequest: (
-      index: number
-    ) => AsyncSync<WdioInterceptorService.InterceptedRequest>;
-    getRequests: () => AsyncSync<WdioInterceptorService.InterceptedRequest[]>;
+    getExpectations: () => AsyncSync<WdioInterceptorService.ExpectedRequest[]>;
+    getRequest(
+      index: number,
+      options?: WdioInterceptorService.GetRequestOptions &
+        WdioInterceptorService.OnlyCompletedRequests
+    ): AsyncSync<WdioInterceptorService.CompletedRequest>;
+    getRequest(
+      index: number,
+      options: WdioInterceptorService.GetRequestOptions
+    ): AsyncSync<WdioInterceptorService.InterceptedRequest>;
+    getRequests(
+      options?: WdioInterceptorService.GetRequestOptions &
+        WdioInterceptorService.OnlyCompletedRequests
+    ): AsyncSync<WdioInterceptorService.CompletedRequest[]>;
+    getRequests(
+      options: WdioInterceptorService.GetRequestOptions
+    ): AsyncSync<WdioInterceptorService.InterceptedRequest[]>;
   }
 }
 


### PR DESCRIPTION
 - Start tracking a request as soon as it is issued, rather than only after it has completed
 - Lay groundwork for future `waitForPendingRequests` option from #111 
   - consumers can write their own version now by wrapping the new `browser.hasPendingRequests()` command
 - deprecates the boolean param to `assertExpectedRequestsOnly`
 - more tests!

I took care to preserve the current behavior of the library w.r.t `getRequest` / `getRequests` ordering, which (despite the previous README's statement) always reported only completed requests, and always ordered by the time of completion. With the new functionality, the next major version of this library could change the default ordering to time of initiation, and could default to waiting for pending requests to settle, etc, -- which are probably the _expected_ behavior for someone new to this library.

Closes #111 
Ref #149 #140 