### PR TITLE
chore: Disable the "wdio-pause" rule, update CHANGELOG, README

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 ## wdio-intercept-service changelog
 
 ### [ [>](https://github.com/webdriverio-community/wdio-intercept-service/tree/v.next) ] v.next / <DATE>
+- Fix header-parsing code to be RFC-compliant (thanks @jbebe)
+- Add new method to allow disabling request interception (thanks @muhserks)
+- Disable the wdio-pause lint rule (thanks @tehhowch)
+
+### [ [>](https://github.com/webdriverio-community/wdio-intercept-service/tree/v4.2.2) ] 4.2.2 / 28.02.2022
 - Wrap xhr::abort and add tests for angular (thanks @lildesert)
 
 ### [ [>](https://github.com/webdriverio-community/wdio-intercept-service/tree/v4.2.1) ] 4.2.1 / 20.12.2021

--- a/README.md
+++ b/README.md
@@ -125,6 +125,10 @@ This library offers a small amount of configuration when issuing commands. Confi
 
 Captures ajax calls in the browser. You always have to call the setup function in order to assess requests later.
 
+### browser.disableInterceptor()
+
+Prevents further capture of ajax calls in the browser. All captured request information is removed. Most users will not need to disable the interceptor, but if a test is particularly long-running or exceeds the session storage capacity, then disabling the interceptor can be helpful.
+
 ### browser.expectRequest(method: string, url: string, statusCode: number)
 
 Make expectations about the ajax requests that are going to be initiated during the test. Can (and should) be chained. The order of the expectations should map to the order of the requests being made.

--- a/test/spec/plugin_test.js
+++ b/test/spec/plugin_test.js
@@ -1,3 +1,4 @@
+/* eslint-disable wdio/no-pause */
 'use strict';
 
 const assert = require('assert');


### PR DESCRIPTION
 - Fixes the lint test. A new rule (`wdio-pause`) was enabled by default in a minor/patch version of the wdio lint plugin. Doing so is a semver violation and broke this repo's build.
 - Adds the latest functionality information to the CHANGELOG.md file and README.md