### PR TITLE
feat(getRequest): provide prompt feedback about an incorrect "index" parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,13 @@
 ## wdio-intercept-service changelog
 
 ### [ [>](https://github.com/webdriverio-community/wdio-intercept-service/tree/v.next) ] v.next / <DATE>
+- Promptly throw if the user passes an invalid "index" parameter to `getRequest`
+- Use Express directly, rather than wdio-static-server-service
+
+### [ [>](https://github.com/webdriverio-community/wdio-intercept-service/tree/v4.3.0) ] 4.3.1 / 21.12.2022
 - Handle responses with no headers (thanks @dragosMC91)
+- Update GitHub Actions workflows to enable auto-merged dependabot PRs
+- Upgrade WDIO dependencies to latest v7, lockfile v2
 
 ### [ [>](https://github.com/webdriverio-community/wdio-intercept-service/tree/v4.3.0) ] 4.3.0 / 17.10.2022
 - Fix header-parsing code to be RFC-compliant (thanks @jbebe)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,11 @@
 ## wdio-intercept-service changelog
 
 ### [ [>](https://github.com/webdriverio-community/wdio-intercept-service/tree/v.next) ] v.next / <DATE>
+
+### [ [>](https://github.com/webdriverio-community/wdio-intercept-service/tree/v4.3.0) ] 4.4.0 / 24.02.2023
 - Promptly throw if the user passes an invalid "index" parameter to `getRequest`
 - Use Express directly, rather than wdio-static-server-service
+- Upgrade WDIO dependencies to latest v8
 
 ### [ [>](https://github.com/webdriverio-community/wdio-intercept-service/tree/v4.3.0) ] 4.3.1 / 21.12.2022
 - Handle responses with no headers (thanks @dragosMC91)

--- a/index.js
+++ b/index.js
@@ -278,16 +278,25 @@ class WebdriverAjax {
     }
 
     async function getRequest(index, options = {}) {
+      const hasIndex = typeof index === 'number';
+      if (typeof index !== 'undefined' && !hasIndex) {
+        throw new TypeError(
+          `${PKG_PREFIX}the "index" property must be a non-negative integer`
+        );
+      }
+      if (hasIndex && index < 0) {
+        throw new RangeError(
+          `${PKG_PREFIX}the "index" property must be a non-negative integer`
+        );
+      }
       const request = await browser.execute(
         interceptor.getRequest,
-        index > -1 ? index : undefined,
+        hasIndex ? index : undefined,
         options
       );
       if (!request) {
-        if (index != null) {
-          return Promise.reject(
-            new Error('Could not find request with index ' + index)
-          );
+        if (hasIndex) {
+          throw new Error('Could not find request with index ' + index);
         }
         return [];
       }

--- a/test/spec/plugin_test.js
+++ b/test/spec/plugin_test.js
@@ -771,4 +771,20 @@ describe('webdriverajax', function testSuite() {
       });
     });
   });
+
+  describe('getRequest', function () {
+    it('throws a TypeError if the index is given and not a number', async function () {
+      await assert.rejects(
+        () => browser.getRequest({ includePending: true }),
+        /TypeError.+index.+non-negative integer/
+      );
+    });
+
+    it('throws a RangeError if the index is given but is negative', async function () {
+      await assert.rejects(
+        () => browser.getRequest(-1),
+        /RangeError.+index.+non-negative integer/
+      );
+    });
+  });
 });


### PR DESCRIPTION
It's fairly easy to conflate `getRequest` and `getRequests`, and they have different signatures. Rather than silently treat a non-numeric index as a call to `getRequests`, throw.

 - update the changelog

Discovered this issue while investigating #505 