### PR TITLE
chore(DX): use a pre-push lint hook, rather than a pre-commit hook

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,0 @@
-#!/bin/sh
-. "$(dirname "$0")/_/husky.sh"
-
-npm run fix && git add \*.js && git add \*.ts

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,0 +1,4 @@
+#!/bin/sh
+. "$(dirname "$0")/_/husky.sh"
+
+npm run prettier:check

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "main": "index.js",
   "scripts": {
     "fix": "prettier --write \"**/*.{js,ts,yml,yaml}\"",
+    "prettier:check": "prettier --check \"**/*.{js,ts,yml,yaml}\"",
     "lint": "eslint --fix .",
     "release": "release-it --github.release",
     "release:ci": "npm run release -- --ci --npm.skipChecks --no-git.requireCleanWorkingDir",


### PR DESCRIPTION
It's infuriating to have code automatically commit everything you've modified, along with silently modifying and committing additional changes, especially when you are trying to create atomic commits.